### PR TITLE
TypeScript package generator.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ members = [
 	"syntax",
 	"cli",
 	"json-schema",
-	"json-ld-context"
+	"json-ld-context",
+	"typescript"
 ]

--- a/typescript/.gitignore
+++ b/typescript/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/typescript/.rustfmt.toml
+++ b/typescript/.rustfmt.toml
@@ -1,0 +1,1 @@
+hard_tabs = true

--- a/typescript/Cargo.toml
+++ b/typescript/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "treeldr-typescript"
+version = "0.1.0"
+authors = ["Spruce Systems Inc."]
+description = "TypeScript package generator for TreeLDR."
+edition = "2021"
+
+[dependencies]
+treeldr = { path = "../core", version = "0.1" }
+log = "0.4"
+iref = "2.0"
+clap = { version = "3.0", features = ["derive"] }
+derivative = "2.2.0"

--- a/typescript/src/command.rs
+++ b/typescript/src/command.rs
@@ -1,0 +1,5 @@
+#[derive(clap::Args)]
+/// Generate a TypeScript package from a TreeLDR model.
+pub struct Command {
+	// ...
+}

--- a/typescript/src/lib.rs
+++ b/typescript/src/lib.rs
@@ -1,0 +1,3 @@
+mod command;
+
+pub use command::Command;


### PR DESCRIPTION
This is an early PR to track/discuss the new `treeldr-typescript` library whose purpose is to generate a TypeScript package from a TreeLDR model. The package should be publishable to npm, and embed JavaScript DIDKit for W3C VC + DID functionality if needed.