### PR TITLE
New json ld context generator

### DIFF
--- a/core/src/layout.rs
+++ b/core/src/layout.rs
@@ -100,6 +100,10 @@ impl<F> Description<F> {
 		}
 	}
 
+	pub fn is_required(&self) -> bool {
+		matches!(self, Self::Required(_)) // TODO checks for non-empty sets
+	}
+
 	pub fn set_name(
 		&mut self,
 		new_name: Name,
@@ -188,6 +192,10 @@ impl<F> Definition<F> {
 
 	pub fn description_with_causes(&self) -> &WithCauses<Description<F>, F> {
 		&self.desc
+	}
+
+	pub fn is_required(&self) -> bool {
+		self.desc.is_required()
 	}
 
 	pub fn label<'m>(&self, model: &'m crate::Model<F>) -> Option<&'m str> {

--- a/core/src/layout/structure.rs
+++ b/core/src/layout/structure.rs
@@ -143,6 +143,11 @@ impl<F> Field<F> {
 		&self.layout
 	}
 
+	pub fn is_required(&self, model: &crate::Model<F>) -> bool {
+		let layout = model.layouts().get(self.layout()).unwrap();
+		layout.is_required()
+	}
+
 	pub fn set_layout(&mut self, layout: Ref<layout::Definition<F>>, causes: impl Into<Causes<F>>) {
 		self.layout = WithCauses::new(layout, causes)
 	}

--- a/examples/simple.tldr
+++ b/examples/simple.tldr
@@ -1,4 +1,4 @@
-base <https://example.com>
+base <https://example.com>;
 
 type Foo {
 	bar: Bar

--- a/examples/simple.tldr
+++ b/examples/simple.tldr
@@ -5,5 +5,5 @@ type Foo {
 }
 
 type Bar {
-	foo: Foo,
+	foo: Foo
 }

--- a/modules/json-ld-context/Cargo.toml
+++ b/modules/json-ld-context/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 treeldr = { path = "../../core", version = "0.1" }
-json-ld = { git = "https://github.com/timothee-haudebourg/json-ld.git", rev = "67d797b" }
+json-ld = { git = "https://github.com/timothee-haudebourg/json-ld.git", rev = "9366eb7" }
 log = "0.4"
 iref = "2.2"
 serde_json = "1.0"

--- a/modules/json-ld-context/Cargo.toml
+++ b/modules/json-ld-context/Cargo.toml
@@ -13,3 +13,4 @@ iref = "2.2"
 serde_json = "1.0"
 clap = { version = "3.0", features = ["derive"] }
 locspan = "0.7.3"
+derivative = "2.2.0"

--- a/modules/json-ld-context/src/command.rs
+++ b/modules/json-ld-context/src/command.rs
@@ -5,9 +5,8 @@ use treeldr::{layout, Ref, Vocabulary};
 #[derive(clap::Args)]
 /// Generate a JSON-LD Context from a TreeLDR model.
 pub struct Command {
-	#[clap(multiple_occurrences(true))]
 	/// Layout schemas to generate.
-	layouts: Vec<IriBuf>
+	layouts: Vec<IriBuf>,
 }
 
 pub enum Error<F> {
@@ -69,7 +68,7 @@ impl Command {
 				println!("{}", definition.pretty_print());
 
 				Ok(())
-			},
+			}
 			Err(e) => Err(Error::Generation(e)),
 		}
 	}

--- a/modules/json-ld-context/src/command.rs
+++ b/modules/json-ld-context/src/command.rs
@@ -7,11 +7,7 @@ use treeldr::{layout, Ref, Vocabulary};
 pub struct Command {
 	#[clap(multiple_occurrences(true))]
 	/// Layout schemas to generate.
-	layouts: Vec<IriBuf>,
-
-	#[clap(short = 't', long = "type")]
-	/// Define a `@type` keyword alias.
-	type_property: Option<String>,
+	layouts: Vec<IriBuf>
 }
 
 pub enum Error<F> {
@@ -67,8 +63,13 @@ impl Command {
 			layouts.push(find_layout(vocabulary, model, layout_iri.as_iri())?);
 		}
 
-		match crate::generate(vocabulary, model, layouts, self.type_property) {
-			Ok(()) => Ok(()),
+		match crate::generate(vocabulary, model, layouts) {
+			Ok(definition) => {
+				use json_ld::syntax::Print;
+				println!("{}", definition.pretty_print());
+
+				Ok(())
+			},
 			Err(crate::Error::Serialization(e)) => Err(Error::Serialization(e)),
 		}
 	}

--- a/modules/json-ld-context/src/command.rs
+++ b/modules/json-ld-context/src/command.rs
@@ -1,3 +1,4 @@
+use crate::Options;
 use iref::{Iri, IriBuf};
 use std::fmt;
 use treeldr::{layout, Ref, Vocabulary};
@@ -7,6 +8,10 @@ use treeldr::{layout, Ref, Vocabulary};
 pub struct Command {
 	/// Layout schemas to generate.
 	layouts: Vec<IriBuf>,
+
+	/// Use layout name as `rdf:type` value.
+	#[clap(long = "rdf-type-to-layout-name")]
+	rdf_type_to_layout_name: bool,
 }
 
 pub enum Error<F> {
@@ -62,7 +67,11 @@ impl Command {
 			layouts.push(find_layout(vocabulary, model, layout_iri.as_iri())?);
 		}
 
-		match crate::generate(vocabulary, model, layouts) {
+		let options = Options {
+			rdf_type_to_layout_name: self.rdf_type_to_layout_name,
+		};
+
+		match crate::generate(vocabulary, model, options, layouts) {
 			Ok(definition) => {
 				use json_ld::syntax::Print;
 				println!("{}", definition.pretty_print());

--- a/modules/json-ld-context/src/command.rs
+++ b/modules/json-ld-context/src/command.rs
@@ -13,7 +13,7 @@ pub struct Command {
 pub enum Error<F> {
 	UndefinedLayout(IriBuf),
 	NotALayout(IriBuf, treeldr::node::CausedTypes<F>),
-	Serialization(serde_json::Error),
+	Generation(crate::Error),
 }
 
 impl<F> fmt::Display for Error<F> {
@@ -21,7 +21,7 @@ impl<F> fmt::Display for Error<F> {
 		match self {
 			Self::UndefinedLayout(iri) => write!(f, "undefined layout `{}`", iri),
 			Self::NotALayout(iri, _) => write!(f, "node `{}` is not a layout", iri),
-			Self::Serialization(e) => write!(f, "JSON serialization failed: {}", e),
+			Self::Generation(e) => e.fmt(f),
 		}
 	}
 }
@@ -70,7 +70,7 @@ impl Command {
 
 				Ok(())
 			},
-			Err(crate::Error::Serialization(e)) => Err(Error::Serialization(e)),
+			Err(e) => Err(Error::Generation(e)),
 		}
 	}
 }

--- a/modules/json-ld-context/src/lib.rs
+++ b/modules/json-ld-context/src/lib.rs
@@ -1,11 +1,13 @@
 use derivative::Derivative;
-use json_ld::syntax::{context::term_definition, Container, ContainerKind, Entry, Nullable};
+use json_ld::syntax::{
+	context::term_definition, Container, ContainerKind, Entry, Keyword, Nullable,
+};
 use locspan::Meta;
 use std::collections::HashMap;
 use std::fmt;
 use treeldr::{
 	layout::{self, Field},
-	prop,
+	prop, ty,
 	vocab::Display,
 	Ref, Vocabulary,
 };
@@ -13,11 +15,23 @@ use treeldr::{
 mod command;
 pub use command::Command;
 
+/// Generator options.
+#[derive(Default)]
+pub struct Options {
+	rdf_type_to_layout_name: bool,
+}
+
 #[derive(Derivative)]
-#[derivative(PartialEq(bound = ""))]
-pub struct TermDefinition<F> {
-	property_ref: Ref<prop::Definition<F>>,
-	layout_ref: Ref<layout::Definition<F>>,
+#[derivative(PartialEq(bound = ""), Clone(bound = ""), Copy(bound = ""))]
+pub enum TermDefinition<F> {
+	Property {
+		property_ref: Ref<prop::Definition<F>>,
+		layout_ref: Ref<layout::Definition<F>>,
+	},
+	Type {
+		type_ref: Ref<ty::Definition<F>>,
+		layout_ref: Ref<layout::Definition<F>>,
+	},
 }
 
 impl<F> TermDefinition<F> {
@@ -27,37 +41,74 @@ impl<F> TermDefinition<F> {
 	) -> Result<Nullable<json_ld::syntax::context::TermDefinition<()>>, Error> {
 		let mut definition = json_ld::syntax::context::term_definition::Expanded::new();
 
-		let property = builder.model.properties().get(self.property_ref).unwrap();
-		let syntax_id =
-			term_definition::Id::Term(property.id().display(builder.vocabulary).to_string());
+		match *self {
+			Self::Property {
+				property_ref,
+				layout_ref,
+			} => {
+				let id = if builder.is_type_property(property_ref) {
+					term_definition::Id::Keyword(Keyword::Type)
+				} else {
+					let property = builder.model.properties().get(property_ref).unwrap();
+					term_definition::Id::Term(property.id().display(builder.vocabulary).to_string())
+				};
 
-		definition.id = Some(Entry::new((), Meta(Nullable::Some(syntax_id), ())));
-		definition.type_ = builder.generate_term_definition_type(self.layout_ref);
-		definition.container = builder.generate_term_definition_container(self.layout_ref);
-		definition.context = builder.generate_term_definition_context(self.layout_ref)?;
+				definition.id = Some(Entry::new((), Meta(Nullable::Some(id), ())));
+				definition.type_ = builder.generate_property_definition_type(layout_ref);
+				definition.container = builder.generate_property_definition_container(layout_ref);
+				definition.context = builder.generate_property_definition_context(layout_ref)?;
+			}
+			Self::Type {
+				type_ref,
+				layout_ref,
+			} => {
+				let ty = builder.model.types().get(type_ref).unwrap();
+				let syntax_id =
+					term_definition::Id::Term(ty.id().display(builder.vocabulary).to_string());
+
+				definition.id = Some(Entry::new((), Meta(Nullable::Some(syntax_id), ())));
+				definition.context = builder.generate_type_definition_context(layout_ref)?;
+			}
+		}
 
 		Ok(definition.simplify())
 	}
 }
 
+type ContextEntry = Entry<Box<json_ld::syntax::context::Value<()>>, ()>;
+
 pub struct ContextBuilder<'a, F> {
 	vocabulary: &'a Vocabulary,
 	model: &'a treeldr::Model<F>,
+	options: &'a Options,
 	parent: Option<&'a ContextBuilder<'a, F>>,
 	terms: HashMap<String, TermDefinition<F>>,
+	do_propagate: bool,
 }
 
 impl<'a, F> ContextBuilder<'a, F> {
 	pub fn new(
 		vocabulary: &'a Vocabulary,
 		model: &'a treeldr::Model<F>,
+		options: &'a Options,
 		parent: Option<&'a ContextBuilder<'a, F>>,
+		do_propagate: bool,
 	) -> Self {
 		Self {
 			vocabulary,
 			model,
+			options,
 			parent,
 			terms: HashMap::new(),
+			do_propagate,
+		}
+	}
+
+	pub fn propagate_context(&'a self) -> Option<&'a ContextBuilder<'a, F>> {
+		if self.do_propagate {
+			Some(self)
+		} else {
+			self.parent
 		}
 	}
 
@@ -75,49 +126,100 @@ impl<'a, F> ContextBuilder<'a, F> {
 		}
 	}
 
+	pub fn insert(&mut self, term: String, definition: TermDefinition<F>) -> Result<(), Error> {
+		if let Some(parent) = self.parent {
+			if parent.contains(&term, &definition) {
+				return Ok(());
+			}
+		}
+
+		use std::collections::hash_map::Entry;
+		match self.terms.entry(term) {
+			Entry::Vacant(entry) => {
+				entry.insert(definition);
+				Ok(())
+			}
+			Entry::Occupied(entry) => {
+				if *entry.get() != definition {
+					Err(Error::Ambiguity(entry.key().clone()))
+				} else {
+					Ok(())
+				}
+			}
+		}
+	}
+
 	pub fn insert_field(&mut self, field: &'a Field<F>) -> Result<(), Error> {
 		match field.property() {
 			Some(property_ref) => {
 				let term = field.name().to_string();
-				let definition = TermDefinition {
+				let definition = TermDefinition::Property {
 					property_ref,
 					layout_ref: field.layout(),
 				};
 
-				if let Some(parent) = self.parent {
-					if parent.contains(&term, &definition) {
-						return Ok(());
-					}
-				}
-
-				use std::collections::hash_map::Entry;
-				match self.terms.entry(term) {
-					Entry::Vacant(entry) => {
-						entry.insert(definition);
-						Ok(())
-					}
-					Entry::Occupied(entry) => {
-						if *entry.get() != definition {
-							Err(Error::Ambiguity(entry.key().clone()))
-						} else {
-							Ok(())
-						}
-					}
-				}
+				self.insert(term, definition)
 			}
 			None => Ok(()),
 		}
 	}
 
-	pub fn insert_layout(&mut self, layout_ref: Ref<layout::Definition<F>>) -> Result<(), Error> {
+	pub fn is_type_property(&self, property_ref: Ref<prop::Definition<F>>) -> bool {
+		let property = self.model.properties().get(property_ref).unwrap();
+		match property.id().as_iri() {
+			Some(iri) => iri.iri(self.vocabulary).unwrap() == json_ld::rdf::RDF_TYPE,
+			None => false,
+		}
+	}
+
+	pub fn is_type_field(&self, field: &Field<F>) -> bool {
+		match field.property() {
+			Some(property_ref) => self.is_type_property(property_ref),
+			None => false,
+		}
+	}
+
+	pub fn insert_typed_layout(
+		&mut self,
+		layout_ref: Ref<layout::Definition<F>>,
+	) -> Result<(), Error> {
+		let layout = self.model.layouts().get(layout_ref).unwrap();
+
+		let term = layout.name().unwrap().to_string();
+		let definition = TermDefinition::Type {
+			type_ref: layout.ty().unwrap(),
+			layout_ref,
+		};
+
+		self.insert(term, definition)
+	}
+
+	pub fn insert_layout_terms(
+		&mut self,
+		layout_ref: Ref<layout::Definition<F>>,
+		typed: bool,
+	) -> Result<(), Error> {
 		let layout = self.model.layouts().get(layout_ref).unwrap();
 
 		use treeldr::layout::Description;
 		match layout.description() {
-			Description::Set(s) => self.insert_layout(s.item_layout()),
-			Description::Required(o) => self.insert_layout(o.item_layout()),
-			Description::Option(o) => self.insert_layout(o.item_layout()),
+			Description::Set(s) => self.insert_layout_terms(s.item_layout(), typed),
+			Description::Required(o) => self.insert_layout_terms(o.item_layout(), typed),
+			Description::Option(o) => self.insert_layout_terms(o.item_layout(), typed),
 			Description::Struct(s) => {
+				if !typed && self.options.rdf_type_to_layout_name {
+					// check if there is a required `rdf:type` property field.
+					for field in s.fields() {
+						if field.is_required(self.model) && self.is_type_field(field) {
+							self.insert_field(field)?;
+							self.insert_typed_layout(layout_ref)?;
+
+							return Ok(());
+						}
+					}
+				}
+
+				// otherwise, include the fields directly in this context.
 				for field in s.fields() {
 					self.insert_field(field)?
 				}
@@ -128,14 +230,44 @@ impl<'a, F> ContextBuilder<'a, F> {
 		}
 	}
 
-	/// Generate the `@context` entry of a term definition.
-	fn generate_term_definition_context(
+	/// Generate the `@context` entry of a property definition.
+	fn generate_property_definition_context(
 		&self,
 		layout_ref: Ref<layout::Definition<F>>,
-	) -> Result<Option<Entry<Box<json_ld::syntax::context::Value<()>>, ()>>, Error> {
-		let mut builder = ContextBuilder::new(self.vocabulary, self.model, Some(self));
+	) -> Result<Option<ContextEntry>, Error> {
+		let mut builder = ContextBuilder::new(
+			self.vocabulary,
+			self.model,
+			self.options,
+			self.propagate_context(),
+			true,
+		);
 
-		builder.insert_layout(layout_ref)?;
+		builder.insert_layout_terms(layout_ref, false)?;
+
+		if builder.is_empty() {
+			Ok(None)
+		} else {
+			let context = builder.build()?;
+
+			Ok(Some(Entry::new((), Meta(Box::new(context), ()))))
+		}
+	}
+
+	/// Generate the `@context` entry of a type definition.
+	fn generate_type_definition_context(
+		&self,
+		layout_ref: Ref<layout::Definition<F>>,
+	) -> Result<Option<ContextEntry>, Error> {
+		let mut builder = ContextBuilder::new(
+			self.vocabulary,
+			self.model,
+			self.options,
+			self.propagate_context(),
+			false,
+		);
+
+		builder.insert_layout_terms(layout_ref, true)?;
 
 		if builder.is_empty() {
 			Ok(None)
@@ -147,7 +279,7 @@ impl<'a, F> ContextBuilder<'a, F> {
 	}
 
 	/// Generate the `@type` entry of a term definition.
-	fn generate_term_definition_type(
+	fn generate_property_definition_type(
 		&self,
 		layout_ref: Ref<layout::Definition<F>>,
 	) -> Option<Entry<Nullable<term_definition::Type>, ()>> {
@@ -155,8 +287,8 @@ impl<'a, F> ContextBuilder<'a, F> {
 
 		use treeldr::layout::Description;
 		match layout.description() {
-			Description::Required(r) => self.generate_term_definition_type(r.item_layout()),
-			Description::Option(o) => self.generate_term_definition_type(o.item_layout()),
+			Description::Required(r) => self.generate_property_definition_type(r.item_layout()),
+			Description::Option(o) => self.generate_property_definition_type(o.item_layout()),
 			Description::Primitive(n, _) => {
 				let syntax_ty = generate_primitive_type(n);
 				Some(Entry::new((), Meta(Nullable::Some(syntax_ty), ())))
@@ -166,7 +298,7 @@ impl<'a, F> ContextBuilder<'a, F> {
 	}
 
 	/// Generate the `@container` entry of a term definition.
-	fn generate_term_definition_container(
+	fn generate_property_definition_container(
 		&self,
 		layout_ref: Ref<layout::Definition<F>>,
 	) -> Option<Entry<Nullable<Container<()>>, ()>> {
@@ -219,12 +351,13 @@ impl fmt::Display for Error {
 pub fn generate<F>(
 	vocabulary: &Vocabulary,
 	model: &treeldr::Model<F>,
+	options: Options,
 	layouts: Vec<Ref<layout::Definition<F>>>,
 ) -> Result<json_ld::syntax::context::Value<()>, Error> {
-	let mut builder = ContextBuilder::new(vocabulary, model, None);
+	let mut builder = ContextBuilder::new(vocabulary, model, &options, None, true);
 
 	for layout_ref in layouts {
-		builder.insert_layout(layout_ref)?;
+		builder.insert_layout_terms(layout_ref, false)?;
 	}
 
 	builder.build()

--- a/modules/rust/gen/Cargo.toml
+++ b/modules/rust/gen/Cargo.toml
@@ -18,8 +18,8 @@ treeldr-rust-prelude = { path = "../prelude" }
 chrono = "0.4.19"
 iref = "2.2"
 grdf = "0.11"
-json-ld = { git = "https://github.com/timothee-haudebourg/json-ld.git", rev = "67d797b" }
-json-syntax = "0.6"
+json-ld = { git = "https://github.com/timothee-haudebourg/json-ld.git", rev = "9366eb7" }
+json-syntax = "0.8.11"
 decoded-char = "0.1"
 locspan = "0.7.2"
 async-std = { version = "1.12.0", features = ["attributes"] }

--- a/modules/rust/prelude/Cargo.toml
+++ b/modules/rust/prelude/Cargo.toml
@@ -14,4 +14,4 @@ xsd-types = "0.3"
 chrono = "0.4.19"
 iref = "2.2"
 static-iref = "2.0"
-json-ld = { git = "https://github.com/timothee-haudebourg/json-ld.git", rev = "67d797b", optional = true }
+json-ld = { git = "https://github.com/timothee-haudebourg/json-ld.git", rev = "9366eb7", optional = true }

--- a/modules/rust/prelude/src/json_ld.rs
+++ b/modules/rust/prelude/src/json_ld.rs
@@ -1,7 +1,7 @@
 use crate::rdf::{Literal, Object, Subject};
 use iref::IriBuf;
 use json_ld::ValidReference;
-use rdf_types::{Quad, BlankIdBuf};
+use rdf_types::{BlankIdBuf, Quad};
 
 pub trait IntoJsonLd<M> {
 	fn into_json_ld(self) -> json_ld::syntax::Value<M>;
@@ -42,7 +42,7 @@ pub fn import_quad<'a>(
 
 	let object = match object {
 		json_ld::rdf::Value::Literal(l) => Object::Literal(import_literal(l)),
-		json_ld::rdf::Value::Reference(r) => Object::Id(r.into_rdf_subject())
+		json_ld::rdf::Value::Reference(r) => Object::Id(r.into_rdf_subject()),
 	};
 
 	Quad(subject, predicate, object, graph)
@@ -51,9 +51,7 @@ pub fn import_quad<'a>(
 pub fn import_literal(lit: json_ld::rdf::Literal<IriBuf>) -> Literal<Subject<IriBuf>> {
 	match lit {
 		json_ld::rdf::Literal::String(s) => Literal::String(s),
-		json_ld::rdf::Literal::TypedString(s, ty) => {
-			Literal::TypedString(s, Subject::Iri(ty))
-		}
+		json_ld::rdf::Literal::TypedString(s, ty) => Literal::TypedString(s, Subject::Iri(ty)),
 		json_ld::rdf::Literal::LangString(s, l) => Literal::LangString(s, l),
 	}
 }


### PR DESCRIPTION
The current LD context generator only generates type-scoped contexts with the assumption that incoming LD documents will always advertise the type of every node using a `@type` property. For instance, take the following TreeLDR schema:
```tldr
base <https://example.com>;

type Foo {
  bar: Bar
}

type Bar {
  foo: Foo
}
```
using the command `tldrc -i example.tldr json-ld-context https://example.com/Foo https://example.com/Bar`, the following LD context is generated:
```json
{
  "Foo": {
    "@id": "https://example.com/Foo",
    "bar": "https://example.com/Bar"
  }
  "Bar": {
    "@id": "https://example.com/Bar",
    "foo": "https://example.com/Foo"
  }
}
```
This is correct for an input LD document such as this:
```json
{
  "@type": "Foo",
  "bar": {
    "@type": "Bar",
    "foo": {}
  }
}
```
Note how each node contains a `@type` entry, which is not specified in the original TreeLDR schema. So we want to be able to handle documents where no type is specified, such as
```json
{
  "bar": {
    "foo": {}
  }
}
```
However it is not possible to specify the type of all the nodes using the JSON-LD context (specifying a `@type` entry inside the context only apply for value objects).

The purpose of the PR is to create a new LD context generator algorithm without this limitation. Type scoped contexts are useful to avoid conflicts and ambiguities between term definitions, so they should be generated whenever possible. Otherwise, terms should be defined globally, or inside property scoped contexts to avoid clashes whenever possible (if there is no cycle).

For the above example, the following context should be generated:
```json
{
  "bar": "https://example.com/Foo/bar",
  "foo": "https://example.com/Bar/foo"
}
```

# Ambiguous terms

Without type scoped contexts, ambiguities can arise when two layouts define fields with the same name.
```tldr
type Foo {
  bar: Bar,
  prop: A
}

type Bar {
  foo: Foo,
  prop: B
}
```
Here there is an ambiguity on the `prop` term definition. These ambiguities should be detected by the LD context generator.

To solve this ambiguity, we could define some "main" layout (the expected layout of the input documents) and some included secondary layouts. Then the `prop` term of the main layout is defined globally while the `prop` term of the secondary layout is defined in a property-scoped context.

# Type scoped contexts

Type scoped contexts can still be generated at the condition that the TreeLDR layout explicitly contains a *required* field holding its type.
```tldr
type Foo {
  required rdf:type as myType,
  bar: Bar
}
```

Then the following context can be generated:
```json
{
  "myType": "@type",
  "Foo": {
    "bar": "https://example.com/Foo/bar"
  }
}
```

Note: we should allow `@type` to be a valid field name so we can write:
```tldr
type Foo {
  required rdf:type as @type,
  bar: Bar
}
```
which would generate the following context without `@type` alias:
```json
{
  "Foo": {
    "bar": "https://example.com/Foo/bar"
  }
}
```

# External contexts

Sometimes contexts are loaded alongside other contexts. For now, the context generator assumes the generated context will be the only one loader and should include all the term definitions. Instead, it would be nice to specify a list of contexts that will be loaded before the generated one. The generator can then omit the definitions already present in the input contexts.

# Implementation status

- [x] `json-ld` refactor
- [x] Simple implementation without caring for ambiguities 
- [x] Ambiguities detection
- [x] Ambiguities resolution using primary/secondary layouts and property scoped contexts
- [x] Type scoped contexts
- [x] ~~External contexts~~