### PR TITLE
Add `OneOrMany` container layout.

### DIFF
--- a/core/src/layout/one_or_many.rs
+++ b/core/src/layout/one_or_many.rs
@@ -1,0 +1,70 @@
+use super::container::Restrictions;
+use crate::{Id, MetaOption, Name, Ref, SubstituteReferences};
+use locspan::Meta;
+
+/// "One or many" layout.
+#[derive(Clone)]
+pub struct OneOrMany<M> {
+	/// Layout name, if any.
+	name: MetaOption<Name, M>,
+
+	/// Item layout.
+	item: Ref<super::Definition<M>>,
+
+	/// Restrictions.
+	restrictions: Restrictions<M>,
+}
+
+impl<M> OneOrMany<M> {
+	pub fn new(
+		name: MetaOption<Name, M>,
+		item: Ref<super::Definition<M>>,
+		restrictions: Restrictions<M>,
+	) -> Self {
+		Self {
+			name,
+			item,
+			restrictions,
+		}
+	}
+
+	pub fn name(&self) -> Option<&Meta<Name, M>> {
+		self.name.as_ref()
+	}
+
+	pub fn set_name(&mut self, new_name: Name, metadata: M) -> Option<Meta<Name, M>> {
+		self.name.replace(new_name, metadata)
+	}
+
+	pub fn into_name(self) -> MetaOption<Name, M> {
+		self.name
+	}
+
+	pub fn item_layout(&self) -> Ref<super::Definition<M>> {
+		self.item
+	}
+
+	pub fn set_item_layout(&mut self, item: Ref<super::Definition<M>>) {
+		self.item = item
+	}
+
+	pub fn restrictions(&self) -> &Restrictions<M> {
+		&self.restrictions
+	}
+
+	pub fn is_required(&self) -> bool {
+		self.restrictions.is_required()
+	}
+}
+
+impl<M> SubstituteReferences<M> for OneOrMany<M> {
+	fn substitute_references<I, T, P, L>(&mut self, sub: &crate::ReferenceSubstitution<I, T, P, L>)
+	where
+		I: Fn(Id) -> Id,
+		T: Fn(Ref<crate::ty::Definition<M>>) -> Ref<crate::ty::Definition<M>>,
+		P: Fn(Ref<crate::prop::Definition<M>>) -> Ref<crate::prop::Definition<M>>,
+		L: Fn(Ref<super::Definition<M>>) -> Ref<super::Definition<M>>,
+	{
+		self.item = sub.layout(self.item)
+	}
+}

--- a/core/src/to_rdf.rs
+++ b/core/src/to_rdf.rs
@@ -654,6 +654,7 @@ impl<F> layout::Definition<F> {
 			layout::Description::Option(o) => o.to_rdf(model, self.id(), quads),
 			layout::Description::Array(a) => a.to_rdf(model, self.id(), quads),
 			layout::Description::Set(s) => s.to_rdf(model, self.id(), quads),
+			layout::Description::OneOrMany(s) => s.to_rdf(model, self.id(), quads),
 			layout::Description::Reference(r) => {
 				quads.push(Quad(
 					self.id(),
@@ -756,6 +757,22 @@ impl<F> layout::Set<F> {
 		quads.push(Quad(
 			id,
 			IriIndex::Iri(Term::TreeLdr(vocab::TreeLdr::Set)),
+			model
+				.layouts()
+				.get(self.item_layout())
+				.unwrap()
+				.id()
+				.into_term(),
+			None,
+		))
+	}
+}
+
+impl<F> layout::OneOrMany<F> {
+	pub fn to_rdf(&self, model: &Model<F>, id: Id, quads: &mut Vec<StrippedQuad>) {
+		quads.push(Quad(
+			id,
+			IriIndex::Iri(Term::TreeLdr(vocab::TreeLdr::OneOrMany)),
 			model
 				.layouts()
 				.get(self.item_layout())

--- a/core/src/vocab.rs
+++ b/core/src/vocab.rs
@@ -113,6 +113,10 @@ pub enum TreeLdr {
 	/// Set layout.
 	#[iri("tldr:set")]
 	Set,
+
+	/// "One or many" layout.
+	#[iri("tldr:oneOrMany")]
+	OneOrMany,
 }
 
 #[derive(IriEnum, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]

--- a/modules/json-ld-context/src/lib.rs
+++ b/modules/json-ld-context/src/lib.rs
@@ -246,6 +246,7 @@ impl<'a, V: Vocabulary<Iri = IriIndex, BlankId = BlankIdIndex>, M> ContextBuilde
 		use treeldr::layout::Description;
 		match layout.description().value() {
 			Description::Set(s) => self.insert_layout_terms(s.item_layout(), typed),
+			Description::OneOrMany(s) => self.insert_layout_terms(s.item_layout(), typed),
 			Description::Required(o) => self.insert_layout_terms(o.item_layout(), typed),
 			Description::Option(o) => self.insert_layout_terms(o.item_layout(), typed),
 			Description::Struct(s) => {

--- a/modules/json-ld-context/tests/generate.rs
+++ b/modules/json-ld-context/tests/generate.rs
@@ -216,7 +216,9 @@ positive! {
 	t04: ["http://www.example.com/Foo", "http://www.example.com/Bar"],
 	t05: ["http://www.example.com/Foo"] { rdf_type_to_layout_name: true },
 	t06: ["http://www.example.com/Foo"] { rdf_type_to_layout_name: true },
-	t07: ["http://www.example.com/Foo"] { rdf_type_to_layout_name: true }
+	t07: ["http://www.example.com/Foo"] { rdf_type_to_layout_name: true },
+	t08: ["http://www.example.com/Foo"],
+	t09: ["http://www.example.com/Foo"]
 }
 
 negative! {

--- a/modules/json-ld-context/tests/generate/t08-in.tldr
+++ b/modules/json-ld-context/tests/generate/t08-in.tldr
@@ -1,0 +1,7 @@
+use <https://treeldr.org/> as tldr;
+
+type Integer with tldr:Integer;
+
+type Foo {
+	prop: multiple Integer
+}

--- a/modules/json-ld-context/tests/generate/t08-out.json
+++ b/modules/json-ld-context/tests/generate/t08-out.json
@@ -1,0 +1,6 @@
+{
+	"prop": {
+		"@id": "http://www.example.com/Foo/prop",
+		"@container": "@set"
+	}
+}

--- a/modules/json-ld-context/tests/generate/t09-in.tldr
+++ b/modules/json-ld-context/tests/generate/t09-in.tldr
@@ -1,0 +1,7 @@
+use <https://treeldr.org/> as tldr;
+
+type Integer with tldr:Integer;
+
+type Foo {
+	prop: single multiple Integer
+}

--- a/modules/json-ld-context/tests/generate/t09-out.json
+++ b/modules/json-ld-context/tests/generate/t09-out.json
@@ -1,0 +1,3 @@
+{
+	"prop": "http://www.example.com/Foo/prop"
+}

--- a/modules/json-schema/tests/generate.rs
+++ b/modules/json-schema/tests/generate.rs
@@ -174,5 +174,8 @@ macro_rules! positive {
 }
 
 positive! {
-	t01: "http://www.example.com/Foo"
+	t01: "http://www.example.com/Foo",
+	t02: "http://www.example.com/Foo",
+	t03: "http://www.example.com/Foo",
+	t04: "http://www.example.com/Foo"
 }

--- a/modules/json-schema/tests/generate/t02-in.tldr
+++ b/modules/json-schema/tests/generate/t02-in.tldr
@@ -1,0 +1,7 @@
+use <https://treeldr.org/> as tldr;
+
+type Integer with tldr:Integer;
+
+type Foo {
+	prop: multiple Integer
+}

--- a/modules/json-schema/tests/generate/t02-out.schema.json
+++ b/modules/json-schema/tests/generate/t02-out.schema.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "http://www.example.com/Foo",
+	"properties": {
+		"prop": {
+			"type": "array",
+			"items": {
+				"$ref": "http://www.example.com/Integer"
+			},
+			"uniqueItems": true
+		}
+	},
+	"title": "Foo",
+	"type": "object"
+}

--- a/modules/json-schema/tests/generate/t03-in.tldr
+++ b/modules/json-schema/tests/generate/t03-in.tldr
@@ -1,0 +1,7 @@
+use <https://treeldr.org/> as tldr;
+
+type Integer with tldr:Integer;
+
+type Foo {
+	prop: single multiple Integer
+}

--- a/modules/json-schema/tests/generate/t03-out.schema.json
+++ b/modules/json-schema/tests/generate/t03-out.schema.json
@@ -1,0 +1,22 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "http://www.example.com/Foo",
+	"properties": {
+		"prop": {
+			"oneOf": [
+				{
+					"$ref": "http://www.example.com/Integer"
+				},
+				{
+					"type": "array",
+					"items": {
+						"$ref": "http://www.example.com/Integer"
+					},
+					"uniqueItems": true
+				}
+			]
+		}
+	},
+	"title": "Foo",
+	"type": "object"
+}

--- a/modules/json-schema/tests/generate/t04-in.tldr
+++ b/modules/json-schema/tests/generate/t04-in.tldr
@@ -1,0 +1,7 @@
+use <https://treeldr.org/> as tldr;
+
+type Integer with tldr:Integer;
+
+type Foo {
+	prop: required Integer
+}

--- a/modules/json-schema/tests/generate/t04-out.schema.json
+++ b/modules/json-schema/tests/generate/t04-out.schema.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "http://www.example.com/Foo",
+	"properties": {
+		"prop": {
+			"$ref": "http://www.example.com/Integer"
+		}
+	},
+	"title": "Foo",
+	"type": "object",
+	"required": ["prop"]
+}

--- a/modules/rust/gen/src/ty.rs
+++ b/modules/rust/gen/src/ty.rs
@@ -174,6 +174,9 @@ impl<M> Description<M> {
 			treeldr::layout::Description::Set(s) => {
 				Self::BuiltIn(BuiltIn::BTreeSet(s.item_layout()))
 			}
+			treeldr::layout::Description::OneOrMany(s) => {
+				Self::BuiltIn(BuiltIn::OneOrMany(s.item_layout()))
+			}
 		}
 	}
 }

--- a/syntax/src/build.rs
+++ b/syntax/src/build.rs
@@ -1129,6 +1129,7 @@ impl<M: Clone + Merge> Build<M> for Meta<crate::PropertyDefinition<M>, M> {
 							required = true;
 							required_loc = Some(ann_loc);
 						}
+						crate::Annotation::Single => (),
 					}
 				}
 
@@ -1672,6 +1673,7 @@ impl<M: Clone + Merge> Build<M> for Meta<crate::FieldDefinition<M>, M> {
 
 		let mut required_loc = None;
 		let mut multiple_loc = None;
+		let mut single_loc = None;
 
 		let layout = match def.layout {
 			Some(Meta(layout, _)) => {
@@ -1685,6 +1687,7 @@ impl<M: Clone + Merge> Build<M> for Meta<crate::FieldDefinition<M>, M> {
 					match ann {
 						crate::Annotation::Multiple => multiple_loc = Some(ann_loc),
 						crate::Annotation::Required => required_loc = Some(ann_loc),
+						crate::Annotation::Single => single_loc = Some(ann_loc),
 					}
 				}
 
@@ -1702,7 +1705,19 @@ impl<M: Clone + Merge> Build<M> for Meta<crate::FieldDefinition<M>, M> {
 									.as_layout_mut()
 									.unwrap();
 								let Meta(item_layout_id, item_layout_loc) = layout_id;
-								container_layout.set_set(item_layout_id, multiple_loc)?;
+
+								match single_loc {
+									Some(single_loc) => {
+										container_layout.set_one_or_many(
+											item_layout_id,
+											multiple_loc.merged_with(single_loc),
+										)?;
+									}
+									None => {
+										container_layout.set_set(item_layout_id, multiple_loc)?;
+									}
+								}
+
 								container_layout
 									.restrictions_mut()
 									.container
@@ -1742,7 +1757,19 @@ impl<M: Clone + Merge> Build<M> for Meta<crate::FieldDefinition<M>, M> {
 									.as_layout_mut()
 									.unwrap();
 								let Meta(item_layout_id, item_layout_loc) = layout_id;
-								container_layout.set_set(item_layout_id, multiple_loc)?;
+
+								match single_loc {
+									Some(single_loc) => {
+										container_layout.set_one_or_many(
+											item_layout_id,
+											multiple_loc.merged_with(single_loc),
+										)?;
+									}
+									None => {
+										container_layout.set_set(item_layout_id, multiple_loc)?;
+									}
+								}
+
 								Meta(container_id, item_layout_loc)
 							}
 							None => {

--- a/syntax/src/build/intersection.rs
+++ b/syntax/src/build/intersection.rs
@@ -42,6 +42,7 @@ pub enum IntersectedLayoutDescription<M> {
 	Required(Id),
 	Option(Id),
 	Set(Id),
+	OneOrMany(Id),
 	Array(Array<M>),
 	Alias(Id),
 }
@@ -317,6 +318,7 @@ impl<M: Clone> IntersectedLayoutDescription<M> {
 					treeldr_build::layout::Description::Required(r) => Ok(Self::Required(*r)),
 					treeldr_build::layout::Description::Option(s) => Ok(Self::Option(*s)),
 					treeldr_build::layout::Description::Set(s) => Ok(Self::Set(*s)),
+					treeldr_build::layout::Description::OneOrMany(s) => Ok(Self::OneOrMany(*s)),
 					treeldr_build::layout::Description::Array(a) => Ok(Self::Array(a.clone())),
 					treeldr_build::layout::Description::Alias(a) => Ok(Self::Alias(*a)),
 				},
@@ -385,6 +387,7 @@ impl<M: Clone> IntersectedLayoutDescription<M> {
 			(Self::Enum(a), Self::Enum(b)) => a.is_included_in(b),
 			(Self::Struct(a), Self::Struct(b)) => a.is_included_in(b),
 			(Self::Set(a), Self::Set(b)) => a == b,
+			(Self::OneOrMany(a), Self::OneOrMany(b)) => a == b,
 			(Self::Array(a), Self::Array(b)) => a == b,
 			(Self::Alias(a), Self::Alias(b)) => a == b,
 			_ => false,
@@ -442,7 +445,6 @@ impl<M: Clone> IntersectedLayoutDescription<M> {
 				),
 				Self::Required(a) => match other {
 					Self::Required(b) => {
-						eprintln!("case B");
 						let c = IntersectedLayout::try_from_iter(
 							[Meta::new(a, causes.clone()), Meta::new(b, other_causes)],
 							context,
@@ -469,6 +471,10 @@ impl<M: Clone> IntersectedLayoutDescription<M> {
 				},
 				Self::Set(a) => match other {
 					Self::Set(b) if a == b => Ok(Self::Set(a)),
+					_ => Ok(Self::Never),
+				},
+				Self::OneOrMany(a) => match other {
+					Self::OneOrMany(b) if a == b => Ok(Self::OneOrMany(a)),
 					_ => Ok(Self::Never),
 				},
 				Self::Array(a) => match other {
@@ -527,6 +533,7 @@ impl<M: Clone> IntersectedLayoutDescription<M> {
 			Self::Required(r) => Ok(treeldr_build::layout::Description::Required(r)),
 			Self::Option(o) => Ok(treeldr_build::layout::Description::Option(o)),
 			Self::Set(s) => Ok(treeldr_build::layout::Description::Set(s)),
+			Self::OneOrMany(s) => Ok(treeldr_build::layout::Description::OneOrMany(s)),
 			Self::Array(a) => Ok(treeldr_build::layout::Description::Array(a)),
 			Self::Alias(a) => Ok(treeldr_build::layout::Description::Alias(a)),
 		}

--- a/syntax/src/build/intersection/structure.rs
+++ b/syntax/src/build/intersection/structure.rs
@@ -256,6 +256,7 @@ pub enum FieldLayoutDescription<M> {
 	Option,
 	Array(Option<treeldr_build::layout::array::Semantics<M>>),
 	Set,
+	OneOrMany,
 }
 
 impl<M> FieldLayout<M> {
@@ -281,6 +282,9 @@ impl<M> FieldLayout<M> {
 					LayoutDescription::Standard(treeldr_build::layout::Description::Set(r)) => {
 						(FieldLayoutDescription::Set, *r)
 					}
+					LayoutDescription::Standard(treeldr_build::layout::Description::OneOrMany(
+						r,
+					)) => (FieldLayoutDescription::OneOrMany, *r),
 					LayoutDescription::Standard(treeldr_build::layout::Description::Array(a)) => (
 						FieldLayoutDescription::Array(a.semantics().cloned()),
 						a.item_layout(),
@@ -385,6 +389,7 @@ impl<M> FieldLayoutDescription<M> {
 			(Self::Required, Self::Required | Self::Option) => true,
 			(Self::Option, Self::Option) => true,
 			(Self::Set, Self::Set) => true,
+			(Self::OneOrMany, Self::OneOrMany) => true,
 			(Self::Array(a), Self::Array(b)) => a.stripped() == b.stripped(),
 			_ => false,
 		}
@@ -397,6 +402,7 @@ impl<M> FieldLayoutDescription<M> {
 			| (Self::Option, Self::Required) => Some(Self::Required),
 			(Self::Option, Self::Option) => Some(Self::Option),
 			(Self::Set, Self::Set) => Some(Self::Set),
+			(Self::OneOrMany, Self::OneOrMany) => Some(Self::OneOrMany),
 			(Self::Array(a), Self::Array(b)) if a.stripped() == b.stripped() => {
 				Some(Self::Array(a))
 			}
@@ -429,6 +435,9 @@ impl<M> FieldLayoutDescription<M> {
 			}
 			Self::Set => {
 				layout.set_set(item_layout, item_causes).ok();
+			}
+			Self::OneOrMany => {
+				layout.set_one_or_many(item_layout, item_causes).ok();
 			}
 			Self::Array(semantics) => {
 				layout.set_array(item_layout, semantics, item_causes).ok();

--- a/syntax/src/lib.rs
+++ b/syntax/src/lib.rs
@@ -132,6 +132,12 @@ pub enum Annotation {
 
 	/// Field with multiple values.
 	Multiple,
+
+	/// Field with a single value.
+	///
+	/// In can be combined with `multiple` to use the `one or many` container
+	/// layout.
+	Single,
 }
 
 impl Annotation {
@@ -139,6 +145,7 @@ impl Annotation {
 		match name {
 			"required" => Some(Self::Required),
 			"multiple" => Some(Self::Multiple),
+			"single" => Some(Self::Single),
 			_ => None,
 		}
 	}
@@ -147,6 +154,7 @@ impl Annotation {
 		match self {
 			Self::Required => "required",
 			Self::Multiple => "multiple",
+			Self::Single => "single",
 		}
 	}
 }


### PR DESCRIPTION
Fixes #54

I chose to use this layout when the `multiple` attribute is combined with `single`.