### PR TITLE
Do not trim doc comments.

### DIFF
--- a/syntax/src/build.rs
+++ b/syntax/src/build.rs
@@ -653,8 +653,6 @@ impl<M: Clone + Merge> Build<M> for Meta<crate::Documentation<M>, M> {
 		let mut description_loc = loc;
 
 		for Meta(line, line_loc) in doc.items {
-			let line = line.trim();
-
 			if description.is_empty() {
 				description_loc = line_loc;
 			} else {
@@ -665,7 +663,7 @@ impl<M: Clone + Merge> Build<M> for Meta<crate::Documentation<M>, M> {
 				description.push('\n');
 			}
 
-			description.push_str(line);
+			description.push_str(&line);
 		}
 
 		let description = if description.is_empty() {

--- a/syntax/src/lexing.rs
+++ b/syntax/src/lexing.rs
@@ -540,9 +540,17 @@ impl<E, C: Iterator<Item = Result<DecodedChar, E>>> Lexer<E, C> {
 		match self.expect_char()? {
 			'/' => {
 				// doc
-				self.next_char()?;
+				self.next_char()?; // we already know it is a third '/'.
 
 				let mut doc = String::new();
+
+				// we ignore the first space, if there is one.
+				if let Some(c) = self.next_char()? {
+					if !matches!(c, ' ' | '\n') {
+						doc.push(c)
+					}
+				}
+
 				while let Some(c) = self.next_char()? {
 					if c == '\n' {
 						break;


### PR DESCRIPTION
Fixes #62

Only the first space is trimmed (if there is one).