### PR TITLE
JSON-LD Context Generator: Compact IRIs

### DIFF
--- a/modules/json-ld-context/src/unresolved.rs
+++ b/modules/json-ld-context/src/unresolved.rs
@@ -459,6 +459,33 @@ impl LocalContexts {
 		self.definitions.insert(r, bindings);
 	}
 
+	pub fn add_iri_prefixes(
+		&mut self,
+		prefixes: &HashMap<String, IriIndex>,
+		root: Ref<LocalContext>,
+	) {
+		let definitions: Vec<_> = prefixes
+			.iter()
+			.map(|(prefix, value)| {
+				(
+					prefix.clone(),
+					Nullable::Some(TermDefinition {
+						id: Some(Unresolved::Resolved(json_ld::Term::Ref(
+							json_ld::Id::Valid(Id::Iri(*value)),
+						))),
+						context: self.empty_context(),
+						..Default::default()
+					}),
+				)
+			})
+			.collect();
+
+		let bindings = self.definitions.get_mut(&root).unwrap();
+		for (prefix, def) in definitions {
+			bindings.insert(prefix, def)
+		}
+	}
+
 	pub fn propagated_sub_contexts(
 		&self,
 		r: Ref<LocalContext>,

--- a/modules/json-ld-context/tests/generate_json_ld_context.rs
+++ b/modules/json-ld-context/tests/generate_json_ld_context.rs
@@ -16,6 +16,7 @@ use treeldr_syntax::Parse;
 pub struct Options {
 	rdf_type_to_layout_name: bool,
 	flatten: bool,
+	prefixes: Vec<(&'static str, Iri<'static>)>,
 	context: Option<&'static str>,
 }
 
@@ -44,9 +45,16 @@ impl Options {
 			None => json_ld::Context::default(),
 		};
 
+		let prefixes = self
+			.prefixes
+			.iter()
+			.map(|(prefix, iri)| (prefix.to_string(), vocabulary.insert(*iri)))
+			.collect();
+
 		treeldr_json_ld_context::Options {
 			rdf_type_to_layout_name: self.rdf_type_to_layout_name,
 			flatten: self.flatten,
+			prefixes,
 			context,
 		}
 	}
@@ -285,7 +293,8 @@ positive! {
 	p022: ["http://www.example.com/A"],
 	p023: ["http://www.example.com/Foo"] { rdf_type_to_layout_name: true },
 	p024: ["http://www.example.com/Foo"] { rdf_type_to_layout_name: true, flatten: true },
-	p025: ["http://www.example.com/Bar"] { rdf_type_to_layout_name: true }
+	p025: ["http://www.example.com/Bar"] { rdf_type_to_layout_name: true },
+	p026: ["http://www.example.com/Foo"] { rdf_type_to_layout_name: true, flatten: true, prefixes: vec![("ex", iri!("http://www.example.com/"))] }
 }
 
 negative! {

--- a/modules/json-ld-context/tests/generate_json_ld_context/p026-in.tldr
+++ b/modules/json-ld-context/tests/generate_json_ld_context/p026-in.tldr
@@ -1,0 +1,14 @@
+use <http://www.w3.org/1999/02/22-rdf-syntax-ns#> as rdf;
+use <http://www.w3.org/2000/01/rdf-schema#> as rdfs;
+use <http://www.example.com/> as ex;
+
+type Foo {
+	rdf:type as "@type": required multiple &rdfs:Class,
+	ex:a: Bar
+}
+
+type Bar {
+	rdf:type as "@type": required multiple &rdfs:Class,
+	ex:b: &rdfs:Resource
+}
+

--- a/modules/json-ld-context/tests/generate_json_ld_context/p026-out.json
+++ b/modules/json-ld-context/tests/generate_json_ld_context/p026-out.json
@@ -1,0 +1,10 @@
+{
+	"ex": "http://www.example.com/",
+	"Foo": "ex:Foo",
+	"Bar": "ex:Bar",
+	"a": "ex:a",
+	"b": {
+		"@id": "ex:b",
+		"@type": "@id"
+	}
+}


### PR DESCRIPTION
This is a simplistic implementation.
To make it perfect in the future it should use the set of accessible
prefixes from each local context.

Fixes #93