### PR TITLE
Remove the loader param from the LD context gen.

### DIFF
--- a/modules/json-ld-context/src/command.rs
+++ b/modules/json-ld-context/src/command.rs
@@ -247,7 +247,7 @@ impl Command {
 			}
 		}
 
-		match crate::generate(vocabulary, &mut loader, model, options, &layouts).await {
+		match crate::generate(vocabulary, model, options, &layouts) {
 			Ok(definition) => {
 				use json_ld::syntax::Print;
 				println!("{}", definition.pretty_print());

--- a/modules/json-ld-context/src/lib.rs
+++ b/modules/json-ld-context/src/lib.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 
-use json_ld::{syntax::Keyword, ContextLoader, Nullable};
+use json_ld::{syntax::Keyword, Nullable};
 use locspan::Meta;
 use rdf_types::{IriVocabulary, VocabularyMut};
 use shelves::Ref;
@@ -524,18 +524,14 @@ impl<'a, V: IriVocabulary<Iri = IriIndex>, M> Builder<'a, V, M> {
 }
 
 /// Generate a JSON-LD context from a TreeLDR model.
-pub async fn generate<V, L, M>(
+pub fn generate<V, M>(
 	vocabulary: &mut V,
-	_loader: &mut L,
 	model: &treeldr::MutableModel<M>,
 	options: Options<M>,
 	layouts: &[TId<treeldr::Layout>],
 ) -> Result<json_ld::syntax::context::Value<()>, Error>
 where
 	V: VocabularyMut<Iri = IriIndex, BlankId = BlankIdIndex> + Send + Sync,
-	L: ContextLoader<IriIndex, M> + Send + Sync,
-	L::Context: Into<json_ld::syntax::context::Value<M>>,
-	L::ContextError: Send,
 	M: Clone + Send + Sync,
 {
 	let mut builder = Builder::new(vocabulary, model, options);

--- a/modules/json-ld-context/tests/generate_json_ld_context.rs
+++ b/modules/json-ld-context/tests/generate_json_ld_context.rs
@@ -131,15 +131,9 @@ impl Test {
 				let mut loader = json_ld::NoLoader::<IriIndex, Span>::new();
 				let options = options.load(&mut vocabulary, &mut loader).await;
 
-				let output = treeldr_json_ld_context::generate(
-					&mut vocabulary,
-					&mut loader,
-					&model,
-					options,
-					&layouts,
-				)
-				.await
-				.expect("unable to generate LD context");
+				let output =
+					treeldr_json_ld_context::generate(&mut vocabulary, &model, options, &layouts)
+						.expect("unable to generate LD context");
 
 				let expected = json_ld::syntax::Value::parse_str(expected_output, |_| ())
 					.expect("invalid JSON");
@@ -211,15 +205,9 @@ impl Test {
 				let mut loader = json_ld::NoLoader::<IriIndex, Span>::new();
 				let options = options.load(&mut vocabulary, &mut loader).await;
 
-				let output = treeldr_json_ld_context::generate(
-					&mut vocabulary,
-					&mut loader,
-					&model,
-					options,
-					&layouts,
-				)
-				.await
-				.expect("unable to generate LD context");
+				let output =
+					treeldr_json_ld_context::generate(&mut vocabulary, &model, options, &layouts)
+						.expect("unable to generate LD context");
 
 				eprintln!("output:\n{}", output.pretty_print());
 			}


### PR DESCRIPTION
Removes the useless `loader` parameter from `treeldr_json_ld_context::generate` that makes the function `async`.