### PR TITLE
Allow arbitrary record fields.

### DIFF
--- a/generators/rust/treeldr-rs-macros/src/parse.rs
+++ b/generators/rust/treeldr-rs-macros/src/parse.rs
@@ -4,12 +4,15 @@ use iref::{Iri, IriBuf, IriRefBuf};
 use proc_macro2::{Span, TokenStream, TokenTree};
 use rdf_types::BlankIdBuf;
 use syn::spanned::Spanned;
-use treeldr_layouts::abs::syntax::{
-	BooleanLayout, ByteStringLayout, CompactIri, DataLayout, Dataset, ExtraProperties, Field,
-	IdLayout, Layout, LayoutHeader, ListItem, ListLayout, ListNode, ListNodeOrLayout,
-	LiteralLayout, NumberLayout, OrderedListLayout, Pattern, ProductLayout, Quad, SizedListLayout,
-	SumLayout, TextStringLayout, UnitLayout, UnorderedListLayout, ValueFormat, ValueFormatOrLayout,
-	VariableNameBuf, Variant, VariantFormat, VariantFormatOrLayout,
+use treeldr_layouts::{
+	abs::syntax::{
+		BooleanLayout, ByteStringLayout, CompactIri, DataLayout, Dataset, ExtraProperties, Field,
+		IdLayout, Layout, LayoutHeader, ListItem, ListLayout, ListNode, ListNodeOrLayout,
+		LiteralLayout, NumberLayout, OrderedListLayout, Pattern, ProductLayout, Quad,
+		SizedListLayout, SumLayout, TextStringLayout, UnitLayout, UnorderedListLayout, ValueFormat,
+		ValueFormatOrLayout, VariableNameBuf, Variant, VariantFormat, VariantFormatOrLayout,
+	},
+	Value,
 };
 
 #[derive(Default)]
@@ -205,7 +208,7 @@ pub fn parse(input: syn::DeriveInput) -> Result<ParsedInput, Error> {
 			},
 		))),
 		Kind::Record => {
-			let fields = match input.data {
+			let entries = match input.data {
 				syn::Data::Struct(s) => match s.fields {
 					syn::Fields::Named(fields) => fields
 						.named
@@ -227,7 +230,7 @@ pub fn parse(input: syn::DeriveInput) -> Result<ParsedInput, Error> {
 								required,
 							};
 
-							Ok((name, field))
+							Ok((Value::string(name), field))
 						})
 						.collect::<Result<BTreeMap<_, _>, _>>()?,
 					f => return Err(Error::ExpectedNamedFields(f.span())),
@@ -246,7 +249,7 @@ pub fn parse(input: syn::DeriveInput) -> Result<ParsedInput, Error> {
 					dataset: type_attrs.dataset.unwrap_or_default(),
 					extra: type_attrs.extra.unwrap_or_default(),
 				},
-				fields,
+				fields: entries,
 			})
 		}
 		Kind::Sum => {

--- a/layouts/src/distill/de/mod.rs
+++ b/layouts/src/distill/de/mod.rs
@@ -46,11 +46,11 @@ pub enum Error<R = Term> {
 	#[error("layout `{0}` is undefined")]
 	LayoutNotFound(Ref<LayoutType, R>),
 
-	#[error("missing required field `{field_name}`")]
-	MissingRequiredField {
+	#[error("missing required key `{key}`")]
+	MissingRequiredKey {
 		layout: Ref<ProductLayoutType, R>,
-		field_name: String,
-		value: BTreeMap<String, Value>,
+		key: Value,
+		value: BTreeMap<Value, Value>,
 	},
 }
 
@@ -65,13 +65,13 @@ impl<R> Error<R> {
 			Self::DataAmbiguity => Error::DataAmbiguity,
 			Self::TermAmbiguity(a) => Error::TermAmbiguity(a),
 			Self::LayoutNotFound(layout_ref) => Error::LayoutNotFound(layout_ref.map(f)),
-			Self::MissingRequiredField {
+			Self::MissingRequiredKey {
 				layout,
-				field_name,
+				key: field_name,
 				value,
-			} => Error::MissingRequiredField {
+			} => Error::MissingRequiredKey {
 				layout: layout.map(f),
-				field_name,
+				key: field_name,
 				value,
 			},
 		}
@@ -704,7 +704,7 @@ where
 			}
 		}
 		Layout::Product(layout) => match value {
-			Value::Record(value) => {
+			Value::Map(value) => {
 				let env = env.intro(rdf, layout.intro);
 				env.instantiate_dataset(&layout.dataset, output)?;
 
@@ -727,11 +727,11 @@ where
 					}
 				}
 
-				for (name, field) in &layout.fields {
-					if field.required && !value.contains_key(name) {
-						return Err(Error::MissingRequiredField {
+				for (key, field) in &layout.fields {
+					if field.required && !value.contains_key(key) {
+						return Err(Error::MissingRequiredKey {
 							layout: layout_ref.clone().cast(),
-							field_name: name.clone(),
+							key: key.clone(),
 							value: value.clone(),
 						});
 					}

--- a/layouts/src/distill/hy/mod.rs
+++ b/layouts/src/distill/hy/mod.rs
@@ -57,10 +57,10 @@ pub enum DataFragment<R> {
 		variant_name: String,
 	},
 
-	#[error("field `{field_name}`")]
-	Field {
+	#[error("key `{key}`")]
+	Key {
 		layout: Ref<ProductLayoutType, R>,
-		field_name: String,
+		key: Value,
 	},
 
 	#[error("list node")]
@@ -330,7 +330,7 @@ where
 
 			let mut record = BTreeMap::new();
 
-			for (name, field) in &layout.fields {
+			for (key, field) in &layout.fields {
 				let mut field_substitution = substitution.clone();
 				field_substitution.intro(field.intro);
 
@@ -340,9 +340,9 @@ where
 					field.dataset.quads().with_default_graph(current_graph),
 				)
 				.into_unique()
-				.for_fragment(|| DataFragment::Field {
+				.for_fragment(|| DataFragment::Key {
 					layout: layout_ref.clone().cast(),
-					field_name: name.clone(),
+					key: key.clone(),
 				})?;
 
 				match field_substitution {
@@ -362,20 +362,20 @@ where
 							&field_inputs,
 						)?;
 
-						record.insert(name.clone(), value);
+						record.insert(key.clone(), value);
 					}
 					None => {
 						if field.required {
-							return Err(Error::MissingData(Box::new(DataFragment::Field {
+							return Err(Error::MissingData(Box::new(DataFragment::Key {
 								layout: layout_ref.clone().cast(),
-								field_name: name.clone(),
+								key: key.clone(),
 							})));
 						}
 					}
 				}
 			}
 
-			Ok(TypedValue::Record(record, layout_ref.casted()))
+			Ok(TypedValue::Map(record, layout_ref.casted()))
 		}
 		Layout::List(layout) => {
 			match layout {

--- a/layouts/src/layout/product.rs
+++ b/layouts/src/layout/product.rs
@@ -2,7 +2,7 @@ use educe::Educe;
 use std::collections::BTreeMap;
 use std::hash::Hash;
 
-use crate::{Dataset, Ref, ValueFormat};
+use crate::{Dataset, Ref, Value, ValueFormat};
 
 use super::LayoutType;
 
@@ -24,7 +24,7 @@ pub struct ProductLayout<R> {
 	pub intro: u32,
 
 	/// Fields.
-	pub fields: BTreeMap<String, Field<R>>,
+	pub fields: BTreeMap<Value, Field<R>>,
 
 	/// Dataset.
 	pub dataset: Dataset<R>,

--- a/layouts/src/value/cbor/serde_cbor.rs
+++ b/layouts/src/value/cbor/serde_cbor.rs
@@ -71,12 +71,12 @@ impl<R> TypedValue<R> {
 				inner.try_into_tagged_serde_cbor_with_ref(vocabulary, interpretation, layouts)?,
 				Some(ty.cast()),
 			),
-			Self::Record(map, ty) => (
+			Self::Map(map, ty) => (
 				serde_cbor::Value::Map(
 					map.into_iter()
 						.map(|(key, value)| {
 							Ok((
-								serde_cbor::Value::Text(key),
+								key.into(),
 								value.try_into_tagged_serde_cbor_with_ref(
 									vocabulary,
 									interpretation,
@@ -126,9 +126,9 @@ impl<R> From<TypedValue<R>> for serde_cbor::Value {
 			TypedValue::Literal(TypedLiteral::TextString(s, _)) => Self::Text(s),
 			TypedValue::Literal(TypedLiteral::Id(s, _)) => Self::Text(s),
 			TypedValue::Variant(inner, _, _) => (*inner).into(),
-			TypedValue::Record(map, _) => Self::Map(
+			TypedValue::Map(map, _) => Self::Map(
 				map.into_iter()
-					.map(|(key, value)| (serde_cbor::Value::Text(key), value.into()))
+					.map(|(key, value)| (key.into(), value.into()))
 					.collect(),
 			),
 			TypedValue::List(items, _) => Self::Array(items.into_iter().map(Into::into).collect()),
@@ -165,9 +165,9 @@ impl From<Value> for serde_cbor::Value {
 			Value::Literal(Literal::Number(n)) => n.into(),
 			Value::Literal(Literal::ByteString(bytes)) => serde_cbor::Value::Bytes(bytes),
 			Value::Literal(Literal::TextString(string)) => serde_cbor::Value::Text(string),
-			Value::Record(map) => serde_cbor::Value::Map(
+			Value::Map(map) => serde_cbor::Value::Map(
 				map.into_iter()
-					.map(|(key, value)| (serde_cbor::Value::Text(key), value.into()))
+					.map(|(key, value)| (key.into(), value.into()))
 					.collect(),
 			),
 			Value::List(items) => {

--- a/layouts/src/value/de.rs
+++ b/layouts/src/value/de.rs
@@ -113,7 +113,7 @@ impl<'de> serde::Deserialize<'de> for Value {
 					map.insert(key, value);
 				}
 
-				Ok(Value::Record(map))
+				Ok(Value::Map(map))
 			}
 		}
 

--- a/layouts/src/value/ser.rs
+++ b/layouts/src/value/ser.rs
@@ -7,7 +7,7 @@ impl serde::Serialize for Value {
 	{
 		match self {
 			Self::Literal(literal) => literal.serialize(serializer),
-			Self::Record(record) => {
+			Self::Map(record) => {
 				use serde::ser::SerializeMap;
 				let mut map = serializer.serialize_map(Some(record.len()))?;
 


### PR DESCRIPTION
This PR adds support for non-string record layout fields. I changed TreeLDR's tree data model a bit to allow arbitrary map keys. Unfortunatly non-string keys are not supported by JSON, so its not possible to create such layout with the JSON syntax. There is a DSL comming to define layouts, but in the mean time it's still possible to use any syntax that allows arbitrary map keys, such as CBOR (but its not human readable) or RON.